### PR TITLE
Disable AVX512 for ROCm …

### DIFF
--- a/op_builder/cpu_adam.py
+++ b/op_builder/cpu_adam.py
@@ -42,7 +42,7 @@ class CPUAdamBuilder(CUDAOpBuilder):
         result = subprocess.check_output('lscpu', shell=True)
         result = result.decode('utf-8').strip().lower()
         if 'genuineintel' in result:
-            if 'avx512' in result:
+            if not is_rocm_pytorch and 'avx512' in result:
                 return '-D__AVX512__'
             elif 'avx2' in result:
                 return '-D__AVX256__'


### PR DESCRIPTION
... to enable same build of DeepSpeed to work on Intel and AMD CPUs