### PR TITLE
 Workaround for compilation: fixing HIP path

### DIFF
--- a/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h
+++ b/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h
@@ -34,8 +34,8 @@ THE SOFTWARE.
 
 //#if __cplusplus
 #if __cplusplus && defined(__clang__) && defined(__HIP__)
-#include <hip/hcc_detail/hip_cooperative_groups_helper.h>
-#include <hip/hcc_detail/device_functions.h>
+#include <hip/amd_detail/hip_cooperative_groups_helper.h>
+#include <hip/device_functions.h>
 namespace cooperative_groups {
 
 /** \brief The base type of all cooperative group types

--- a/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h
+++ b/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h
@@ -32,8 +32,8 @@ THE SOFTWARE.
 #define HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COOPERATIVE_GROUPS_HELPER_H
 
 #if __cplusplus
-#include <hip/hcc_detail/hip_runtime_api.h>
-#include <hip/hcc_detail/device_functions.h>
+#include <hip/hip_runtime_api.h>
+#include <hip/device_functions.h>
 
 #if !defined(__align__)
 #define __align__(x) __attribute__((aligned(x)))

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -178,8 +178,8 @@ RUN git clone https://github.com/ROCmSoftwarePlatform/DeepSpeed.git ${STAGE_DIR}
 RUN cd ${STAGE_DIR}/DeepSpeed && \
         git checkout . && \
         git checkout master && \
-        cp -a csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h /opt/rocm/include/hip/hcc_detail/hip_cooperative_groups.h && \
-        cp -a csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h /opt/rocm/include/hip/hcc_detail/hip_cooperative_groups_helper.h && \
+        cp -a csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h /opt/rocm/include/hip/hip_cooperative_groups.h && \
+        cp -a csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h /opt/rocm/include/hip/amd_detail/hip_cooperative_groups_helper.h && \
         DS_BUILD_FUSED_ADAM=1 DS_BUILD_FUSED_LAMB=1 DS_BUILD_CPU_ADAM=1 DS_BUILD_TRANSFORMER=1 DS_BUILD_STOCHASTIC_TRANSFORMER=1 DS_BUILD_UTILS=1 ./install.sh --allow_sudo
 RUN rm -rf ${STAGE_DIR}/DeepSpeed
 RUN cd ~ && python -c "import deepspeed; print(deepspeed.__version__)"


### PR DESCRIPTION
Compilation was failing because of the wrong path in the files.
Corrected the path for compilation.