### PR TITLE
Added ROCM_VERSION compiler directives 

### DIFF
--- a/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h
+++ b/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h
@@ -35,7 +35,9 @@ THE SOFTWARE.
 //#if __cplusplus
 #if __cplusplus && defined(__clang__) && defined(__HIP__)
 #include <hip/hcc_detail/hip_cooperative_groups_helper.h>
-#include <hip/hcc_detail/device_functions.h>
+#if ROCM_VERSION_MINOR < 4
+    #include <hip/hcc_detail/device_functions.h>
+#endif
 namespace cooperative_groups {
 
 /** \brief The base type of all cooperative group types

--- a/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h
+++ b/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h
@@ -32,8 +32,13 @@ THE SOFTWARE.
 #define HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COOPERATIVE_GROUPS_HELPER_H
 
 #if __cplusplus
-#include <hip/hcc_detail/hip_runtime_api.h>
-#include <hip/hcc_detail/device_functions.h>
+
+#if ROCM_VERSION_MINOR < 4
+    #include <hip/hcc_detail/hip_runtime_api.h>
+    #include <hip/hcc_detail/device_functions.h>
+#else
+    #include <hip/hcc_detail/amd_device_functions.h>
+#endif
 
 #if !defined(__align__)
 #define __align__(x) __attribute__((aligned(x)))

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -179,6 +179,7 @@ RUN cd ${STAGE_DIR}/DeepSpeed && \
         git checkout . && \
         git checkout master && \
         cp -a csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h /opt/rocm/include/hip/hcc_detail/hip_cooperative_groups.h && \
+        cp -a csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h /opt/rocm/include/hip/hcc_detail/amd_hip_cooperative_groups.h && \
         cp -a csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h /opt/rocm/include/hip/hcc_detail/hip_cooperative_groups_helper.h && \
         DS_BUILD_FUSED_ADAM=1 DS_BUILD_FUSED_LAMB=1 DS_BUILD_CPU_ADAM=1 DS_BUILD_TRANSFORMER=1 DS_BUILD_STOCHASTIC_TRANSFORMER=1 DS_BUILD_UTILS=1 ./install.sh --allow_sudo
 RUN rm -rf ${STAGE_DIR}/DeepSpeed

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -32,6 +32,14 @@ if TORCH_MAJOR > 1 or (TORCH_MAJOR == 1 and TORCH_MINOR >= 5):
     from torch.utils.cpp_extension import ROCM_HOME
     is_rocm_pytorch = True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
 
+if is_rocm_pytorch:
+    with open('/opt/rocm/.info/version-dev', 'r') as file:
+        ROCM_VERSION_DEV_RAW = file.read()
+    ROCM_MAJOR = ROCM_VERSION_DEV_RAW.split('.')[0]
+    ROCM_MINOR = ROCM_VERSION_DEV_RAW.split('.')[1]
+else:
+    ROCM_MAJOR = '0'
+    ROCM_MINOR = '0'
 
 def installed_cuda_version():
     import torch.utils.cpp_extension
@@ -431,7 +439,9 @@ class CUDAOpBuilder(OpBuilder):
                 '-std=c++14',
                 '-U__HIP_NO_HALF_OPERATORS__',
                 '-U__HIP_NO_HALF_CONVERSIONS__',
-                '-U__HIP_NO_HALF2_OPERATORS__'
+                '-U__HIP_NO_HALF2_OPERATORS__',
+                '-DROCM_VERSION_MAJOR=%s' % ROCM_MAJOR,
+                '-DROCM_VERSION_MINOR=%s' % ROCM_MINOR
             ]
         else:
             args += [

--- a/op_builder/fused_lamb.py
+++ b/op_builder/fused_lamb.py
@@ -4,6 +4,15 @@ Copyright 2020 The Microsoft DeepSpeed Team
 import torch
 from .builder import CUDAOpBuilder, is_rocm_pytorch
 
+if is_rocm_pytorch:
+    with open('/opt/rocm/.info/version-dev', 'r') as file:
+        ROCM_VERSION_DEV_RAW = file.read()
+    ROCM_MAJOR = (ROCM_VERSION_DEV_RAW.split('.')[0])
+    ROCM_MINOR = (ROCM_VERSION_DEV_RAW.split('.')[1])
+else:
+    ROCM_MAJOR = '0'
+    ROCM_MINOR = '0'
+
 
 class FusedLambBuilder(CUDAOpBuilder):
     BUILD_VAR = 'DS_BUILD_FUSED_LAMB'
@@ -27,6 +36,12 @@ class FusedLambBuilder(CUDAOpBuilder):
 
     def nvcc_args(self):
         nvcc_flags=['-O3'] + self.version_dependent_macros()
-        if not is_rocm_pytorch:
+        if is_rocm_pytorch:
+             nvcc_flags+= [
+                '-DROCM_VERSION_MAJOR=%s' % ROCM_MAJOR,
+                '-DROCM_VERSION_MINOR=%s' % ROCM_MINOR
+            ]
+        else:
             nvcc_flags.extend(['-lineinfo', '--use_fast_math'] + self.compute_capability_args())
         return nvcc_flags
+


### PR DESCRIPTION
Added ROCM_VERSION_MINOR and ROCM_VERSION_MAJOR compiler directives to enable the build latest ROCm versions.

cc: @jithunnair-amd 