### PR TITLE
Fix for DeepSpeed build error on ROCm 5.0 and above

### DIFF
--- a/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h
+++ b/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h
@@ -35,7 +35,7 @@ THE SOFTWARE.
 //#if __cplusplus
 #if __cplusplus && defined(__clang__) && defined(__HIP__)
 #include <hip/hcc_detail/hip_cooperative_groups_helper.h>
-#if ROCM_VERSION_MINOR < 4
+#if ROCM_VERSION_MAJOR < 5 and ROCM_VERSION_MINOR < 4
     #include <hip/hcc_detail/device_functions.h>
 #endif
 namespace cooperative_groups {

--- a/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h
+++ b/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 #if __cplusplus
 
-#if ROCM_VERSION_MINOR < 4
+#if ROCM_VERSION_MAJOR < 5 and ROCM_VERSION_MINOR < 4
     #include <hip/hcc_detail/hip_runtime_api.h>
     #include <hip/hcc_detail/device_functions.h>
 #else


### PR DESCRIPTION

The error fatal error: 'hip/hcc_detail/hip_runtime_api.h' file not found dring the DeepSPeed build for ROCm versions 5.0 and above has been fixed

cc: @jithunnair-amd 