### PR TITLE
Workaround to avoid cupy build error

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -156,6 +156,7 @@ RUN rm -rf /usr/lib/python3/dist-packages/yaml && \
 ###############################################################################
 RUN git clone https://github.com/ROCmSoftwarePlatform/cupy ${STAGE_DIR}/cupy
 RUN cd ${STAGE_DIR}/cupy && \
+        git checkout tags/v9.5.0 && \
         git submodule update --init && \
         CUPY_INSTALL_USE_HIP=1 ROCM_HOME=/opt/rocm pip install -e . --no-cache-dir -vvvv
 RUN rm -rf ${STAGE_DIR}/cupy


### PR DESCRIPTION
Workaround to avoid "ERROR: Package 'cupy' requires a different Python: 3.6.13 not in '>=3.7'" during cupy build.
This error started occurring after the latest IFU on https://github.com/ROCmSoftwarePlatform/cupy.git.

NOTE: This PR has to be reverted once ROCm switches to python 3.7 or above

cc: @jithunnair-amd @sunway513 @jeffdaily @amathews-amd 