### PR TITLE
Replace THCudaCheck with C10_CUDA_CHECK

### DIFF
--- a/csrc/lamb/fused_lamb_cuda_kernel.cu
+++ b/csrc/lamb/fused_lamb_cuda_kernel.cu
@@ -508,7 +508,7 @@ void fused_lamb_cuda(at::Tensor& p,
                         lamb_coeff.data<scalar_t>());
             }));
     }
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 }
 
 // template __device__ void reduce_two_vectors_in_register<float,512>(float a, float b, float* g_a,


### PR DESCRIPTION
This issue occurs as THCudaCheck is deprecated and PyTorch now considers  THCDeviceUtils.cuh, THC/THC.h.

DeepSpeed still builds successfully in ROCm4.3.1 docker (rocm/pytorch:rocm4.3.1_ubuntu18.04_py3.6_pytorch_1.10.0) which has an older Pytorch versions.

Fixes https://ontrack-internal.amd.com/browse/SWDEV-314993

Reference: https://github.com/ROCmSoftwarePlatform/apex/pull/55/commits/fec3141c33c23da9f790700817f7496158080712

cc: @jithunnair-amd 