### PR TITLE
Workarounds to enable DeepSpeed transformer inference on ROCm

### DIFF
--- a/csrc/includes/conversion_utils.h
+++ b/csrc/includes/conversion_utils.h
@@ -266,7 +266,12 @@ DS_D_INLINE float2 to(__nv_bfloat162 val)
 template <>
 DS_D_INLINE __half to(double val)
 {
+#ifdef __HIP_PLATFORM_HCC__
+    float val_f = __double2float_rn(val);
+    return __float2half(val_f);
+#else    
     return __double2half(val);
+#endif
 }
 template <>
 DS_D_INLINE __half to(float val)

--- a/csrc/includes/reduction_utils.h
+++ b/csrc/includes/reduction_utils.h
@@ -273,21 +273,33 @@ DS_D_INLINE __half init<ROpType::Max>()
 template <>
 DS_D_INLINE __half2 init<ROpType::Add>()
 {
+#if defined(__HIP_PLATFORM_HCC__)
+    constexpr __half2_raw zero = {0x0000};
+#else
     constexpr __half2_raw zero = {0x0000, 0x0000};
+#endif
     return __half2(zero);
 }
 
 template <>
 DS_D_INLINE __half2 init<ROpType::Min>()
 {
+#if defined(__HIP_PLATFORM_HCC__)
+    constexpr __half2_raw inf = {0x7C00};
+#else
     constexpr __half2_raw inf = {0x7C00, 0x7C00};
+#endif
     return __half2(inf);
 }
 
 template <>
 DS_D_INLINE __half2 init<ROpType::Max>()
 {
+#if defined(__HIP_PLATFORM_HCC__)
+    constexpr __half2_raw neg_inf = {0xFC00};
+#else
     constexpr __half2_raw neg_inf = {0xFC00, 0xFC00};
+#endif
     return __half2(neg_inf);
 }
 

--- a/csrc/includes/reduction_utils.h
+++ b/csrc/includes/reduction_utils.h
@@ -274,7 +274,7 @@ template <>
 DS_D_INLINE __half2 init<ROpType::Add>()
 {
 #if defined(__HIP_PLATFORM_HCC__)
-    constexpr __half2_raw zero = {0x0000};
+    constexpr __half2_raw zero = {_Float16_2{0x0000,0x0000}};
 #else
     constexpr __half2_raw zero = {0x0000, 0x0000};
 #endif
@@ -285,7 +285,7 @@ template <>
 DS_D_INLINE __half2 init<ROpType::Min>()
 {
 #if defined(__HIP_PLATFORM_HCC__)
-    constexpr __half2_raw inf = {0x7C00};
+    constexpr __half2_raw inf = {_Float16_2{0x7C00,0x7C00}};
 #else
     constexpr __half2_raw inf = {0x7C00, 0x7C00};
 #endif
@@ -296,7 +296,7 @@ template <>
 DS_D_INLINE __half2 init<ROpType::Max>()
 {
 #if defined(__HIP_PLATFORM_HCC__)
-    constexpr __half2_raw neg_inf = {0xFC00};
+    constexpr __half2_raw neg_inf = {_Float16_2{0xFC00,0xFC00}};
 #else
     constexpr __half2_raw neg_inf = {0xFC00, 0xFC00};
 #endif

--- a/csrc/transformer/inference/csrc/apply_rotary_pos_emb.cu
+++ b/csrc/transformer/inference/csrc/apply_rotary_pos_emb.cu
@@ -190,10 +190,6 @@ __global__ void apply_rotary_pos_emb1(__half* mixed_query,
             float rotary_sign = (lane > (half_dim - 1) ? -1.0 : 1.0);
             float q_rot = (q * rotary_sign);
             float k_rot = (k * rotary_sign);
-            auto q_rot_tmp = lane < half_dim ? __shfl_sync(mask[lane], q_rot, lane + half_dim)
-                                             : __shfl_sync(mask[lane], q_rot, lane - half_dim);
-            auto k_rot_tmp = lane < half_dim ? __shfl_sync(mask[lane], k_rot, lane + half_dim)
-                                             : __shfl_sync(mask[lane], k_rot, lane - half_dim);
 #if defined(__HIP_PLATFORM_HCC__)
             auto q_rot_tmp = lane < half_dim ? __shfl(q_rot, lane + half_dim)
                                              : __shfl(q_rot, lane - half_dim);

--- a/csrc/transformer/inference/csrc/apply_rotary_pos_emb.cu
+++ b/csrc/transformer/inference/csrc/apply_rotary_pos_emb.cu
@@ -194,6 +194,17 @@ __global__ void apply_rotary_pos_emb1(__half* mixed_query,
                                              : __shfl_sync(mask[lane], q_rot, lane - half_dim);
             auto k_rot_tmp = lane < half_dim ? __shfl_sync(mask[lane], k_rot, lane + half_dim)
                                              : __shfl_sync(mask[lane], k_rot, lane - half_dim);
+#if defined(__HIP_PLATFORM_HCC__)
+            auto q_rot_tmp = lane < half_dim ? __shfl(mask[lane], q_rot, lane + half_dim)
+                                             : __shfl(mask[lane], q_rot, lane - half_dim);
+            auto k_rot_tmp = lane < half_dim ? __shfl(mask[lane], k_rot, lane + half_dim)
+                                             : __shfl(mask[lane], k_rot, lane - half_dim);
+#else
+            auto q_rot_tmp = lane < half_dim ? __shfl_sync(mask[lane], q_rot, lane + half_dim)
+                                             : __shfl_sync(mask[lane], q_rot, lane - half_dim);
+            auto k_rot_tmp = lane < half_dim ? __shfl_sync(mask[lane], k_rot, lane + half_dim)
+                                             : __shfl_sync(mask[lane], k_rot, lane - half_dim);
+#endif
             q = q * cosf(inv_freq) + q_rot_tmp * sinf(inv_freq);
             k = k * cosf(inv_freq) + k_rot_tmp * sinf(inv_freq);
 

--- a/csrc/transformer/inference/csrc/apply_rotary_pos_emb.cu
+++ b/csrc/transformer/inference/csrc/apply_rotary_pos_emb.cu
@@ -195,10 +195,10 @@ __global__ void apply_rotary_pos_emb1(__half* mixed_query,
             auto k_rot_tmp = lane < half_dim ? __shfl_sync(mask[lane], k_rot, lane + half_dim)
                                              : __shfl_sync(mask[lane], k_rot, lane - half_dim);
 #if defined(__HIP_PLATFORM_HCC__)
-            auto q_rot_tmp = lane < half_dim ? __shfl(mask[lane], q_rot, lane + half_dim)
-                                             : __shfl(mask[lane], q_rot, lane - half_dim);
-            auto k_rot_tmp = lane < half_dim ? __shfl(mask[lane], k_rot, lane + half_dim)
-                                             : __shfl(mask[lane], k_rot, lane - half_dim);
+            auto q_rot_tmp = lane < half_dim ? __shfl(q_rot, lane + half_dim)
+                                             : __shfl(q_rot, lane - half_dim);
+            auto k_rot_tmp = lane < half_dim ? __shfl(k_rot, lane + half_dim)
+                                             : __shfl(k_rot, lane - half_dim);
 #else
             auto q_rot_tmp = lane < half_dim ? __shfl_sync(mask[lane], q_rot, lane + half_dim)
                                              : __shfl_sync(mask[lane], q_rot, lane - half_dim);


### PR DESCRIPTION
These changes are required to resolve the following errors when running bloom workload:

1. 
```
/opt/conda/lib/python3.8/site-packages/deepspeed/ops/csrc/includes/conversion_utils_hip.h:270:12: error: use of undeclared identifier '__double2half'; did you mean '__double2hiint'?
    return __double2half(val);
           ^~~~~~~~~~~~~
           __double2hiint
/opt/rocm-5.4.0/include/hip/amd_detail/amd_device_functions.h:440:30: note: '__double2hiint' declared here
__device__ static inline int __double2hiint(double x) {
                             ^
```

2.
```
 /opt/conda/lib/python3.8/site-packages/deepspeed/ops/csrc/transformer/inference/csrc/apply_rotary_pos_emb.hip:195:48: error: use of undeclared identifier '__shfl_sync'
            auto q_rot_tmp = lane < half_dim ? __shfl_sync(mask[lane], q_rot, lane + half_dim)

```

3. 
```
/opt/conda/lib/python3.8/site-packages/deepspeed/ops/csrc/includes/reduction_utils_hip.h:278:43: error: excess elements in struct initializer
    constexpr __half2_raw zero = {0x0000, 0x0000};
                                          ^~~~~~

```