### PR TITLE
__half2_raw initiation error workaround for transformer inference on ROCm

### DIFF
--- a/csrc/includes/reduction_utils.h
+++ b/csrc/includes/reduction_utils.h
@@ -273,21 +273,33 @@ DS_D_INLINE __half init<ROpType::Max>()
 template <>
 DS_D_INLINE __half2 init<ROpType::Add>()
 {
+#if defined(__HIP_PLATFORM_HCC__)
+    constexpr __half2_raw zero = {_Float16_2{0x0000,0x0000}};
+#else
     constexpr __half2_raw zero = {0x0000, 0x0000};
+#endif
     return __half2(zero);
 }
 
 template <>
 DS_D_INLINE __half2 init<ROpType::Min>()
 {
+#if defined(__HIP_PLATFORM_HCC__)
+    constexpr __half2_raw inf = {_Float16_2{0x7C00,0x7C00}};
+#else
     constexpr __half2_raw inf = {0x7C00, 0x7C00};
+#endif
     return __half2(inf);
 }
 
 template <>
 DS_D_INLINE __half2 init<ROpType::Max>()
 {
+#if defined(__HIP_PLATFORM_HCC__)
+    constexpr __half2_raw neg_inf = {_Float16_2{0xFC00,0xFC00}};
+#else
     constexpr __half2_raw neg_inf = {0xFC00, 0xFC00};
+#endif
     return __half2(neg_inf);
 }
 


### PR DESCRIPTION
Error: 

/opt/conda/lib/python3.8/site-packages/deepspeed/ops/csrc/includes/reduction_utils_hip.h:278:43: error: excess elements in struct initializer
    constexpr __half2_raw zero = {0x0000, 0x0000};
                                          ^~~~~~

Related JIRA for proper fix: https://ontrack-internal.amd.com/browse/SWDEV-395559