### PR TITLE
Remove deprecated torch._six imports

### DIFF
--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -16,8 +16,12 @@ from math import floor
 from bisect import bisect_left, bisect_right
 
 import torch
-from torch._six import inf
 import torch.distributed as dist
+
+try:
+    from torch._six import inf as inf
+except ModuleNotFoundError:
+    from torch import inf as inf
 
 from deepspeed.utils import groups, logger
 from deepspeed.runtime.constants import PIPE_REPLICATED

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -16,7 +16,6 @@ from torch.cuda import Event, Stream
 from torch.nn import Module, Parameter
 import torch.distributed as dist
 import math
-from torch._six import inf
 from torch.nn import Module
 from torch.nn.parameter import Parameter
 
@@ -24,7 +23,7 @@ from deepspeed.runtime import ZeROOptimizer
 from deepspeed.utils.logging import logger
 from deepspeed.runtime.fp16.loss_scaler import LossScaler, DynamicLossScaler
 from deepspeed.runtime.comm.coalesced_collectives import reduce_scatter_coalesced
-from deepspeed.runtime.utils import get_global_norm, see_memory_usage, is_model_parallel_parameter, DummyOptim
+from deepspeed.runtime.utils import inf, get_global_norm, see_memory_usage, is_model_parallel_parameter, DummyOptim
 from deepspeed.runtime.zero.partition_parameters import *
 from deepspeed.runtime.zero.partition_parameters import _init_external_params
 from deepspeed.runtime.zero.constants import ZERO_OPTIMIZATION_WEIGHTS

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -5,12 +5,12 @@ Copyright 2019 The Microsoft DeepSpeed Team
 import torch
 from torch.distributed.distributed_c10d import _get_global_rank
 import torch.distributed as dist
-from torch._six import inf
 from packaging import version as pkg_version
 
 from deepspeed.runtime import ZeROOptimizer
 from deepspeed.runtime.fp16.loss_scaler import LossScaler, DynamicLossScaler
-from deepspeed.runtime.utils import (bwc_tensor_model_parallel_rank,
+from deepspeed.runtime.utils import (inf,
+                                     bwc_tensor_model_parallel_rank,
                                      get_global_norm,
                                      see_memory_usage,
                                      is_model_parallel_parameter,


### PR DESCRIPTION
This is a copy of https://github.com/ROCmSoftwarePlatform/DeepSpeed/pull/61

- It is modified version of PR#2863 https://github.com/microsoft/DeepSpeed/pull/2863
- Fixes https://ontrack-internal.amd.com/browse/SWDEV-396029 and few others.