### PR TITLE
Updated numpy version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 hjson
 msgpack
 ninja
-numpy
+numpy==1.26.4
 packaging>=20.0
 psutil
 py-cpuinfo


### PR DESCRIPTION
This PR is to fix incompatible numpy version of pyt_deepspeed_megatron_gpt2 and pyt_train_deepspeed_megatron_gpt2 with PyTorch release/2.5 base docker image.

With the image mentioned above, newer numpy-2.2.1 is downloaded and used instead of using cached numpy-1.26.4. Pinning numpy==1.26.4 could be a more stable way to solve the issue.