### PR TITLE
Fetch rocm version from .info/version file

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -44,7 +44,7 @@ if TORCH_MAJOR > 1 or (TORCH_MAJOR == 1 and TORCH_MINOR >= 5):
     is_rocm_pytorch = True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
 
 if is_rocm_pytorch:
-    with open('/opt/rocm/.info/version-dev', 'r') as file:
+    with open('/opt/rocm/.info/version', 'r') as file:
         ROCM_VERSION_DEV_RAW = file.read()
     ROCM_MAJOR = ROCM_VERSION_DEV_RAW.split('.')[0]
     ROCM_MINOR = ROCM_VERSION_DEV_RAW.split('.')[1]


### PR DESCRIPTION
version-dev is generated by rocm-dev meta package and it's might be possible that user system is not using rocm-dev meta package to install rocm userspace. 

".info/version" is generated by rocm-core meta package which always gets installed whatever the meta package used by user for rocm userspace installed so it's most reliable way to fetch the rocm version in all the cases.
